### PR TITLE
Skip the repo check when a version mismatch doesn't matter

### DIFF
--- a/yay
+++ b/yay
@@ -52,6 +52,11 @@ def query_package(module, pkg, state):
   if local_check_rc != 0:
     return False, False, False
 
+  # No need to check for the repo version in some situations
+  # Indicate the package is out-of-date, because we chose not to check
+  if state == 'present' or state == 'absent':
+    return True, False, False
+
   local_version = get_version(local_check_stdout)
 
   repo_check_cmd = 'yay -Si %s' % pkg


### PR DESCRIPTION
Hi :)

It's up to you if you want to accept this change or not, but I thought it would be a worthwhile change to suggest

I made a similar change to the `pacman` Ansible module, and in my testing it sped up some `pacman` usage by 73% :smile: 
https://github.com/ansible-collections/community.general/pull/3606

Happy to answer any questions or concerns you might have!