### PR TITLE
Yay can now be run from root using become_user

### DIFF
--- a/yay
+++ b/yay
@@ -102,7 +102,12 @@ def upgrade(module):
 def get_sudo_user(module):
   # ansible sets the SUDO_USER environment variable.  Default to using this,
   # checking USER and then `logname` as backups.
-  user = os.environ.get('SUDO_USER') or os.environ.get('USER')
+  user = os.environ.get('SUDO_USER')
+
+  # If ansible is run as root with become_user set, use the specified user
+  # instead of root.
+  if not user or user == 'root':
+    user = os.environ.get('USER')
 
   if not user:
     rc, stdout, _ = module.run_command('logname', check_rc=True)


### PR DESCRIPTION
Hi!

I'm not sure if you want any PRs but here goes...

### What

With this PR, `ansible-yay` can be run using Ansible from the root user when `become: true` and `become_user: <user>` are specified.

### Background

I am developing a playbook for myself that sets up an entire system from a very minimal arch install. I want this to be run from the root user as part of the script is setting up user(s) etc. In the current state, `ansible-yay` will run installation as `sudo -u root yay ...` which obviously won't work. I thus want to be able to run `ansible-yay` using the newly created user, example:

```yaml
- yay: 
    name: "[...]"
    state: present
  become: true
  become_user: "{{ username }}"
```
This PR implements the change I made to solve this issue.
